### PR TITLE
marine buffs, nerfs stun meta

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
@@ -148,6 +148,8 @@
         crate: RMCCrateGlassSheets
       - cost: 2000
         crate: RMCCrateWoodenPlanks
+      - cost: 6000
+        crate: RMCCrateSentries
 #      - cost: 2000
 #        crate: RMCCrateFoldingBarricades
 #      - cost: 3000
@@ -267,6 +269,8 @@
         crate: RMCCrateRestrictedEquipmentArmorM4
       - cost: 2000
         crate: RMCCrateRestrictedEquipmentArmorB12
+      - cost: 5000
+        crate: RMCCrateRestrictedEquipmentGuideKits
     - name: Supplies
       entries:
       - cost: 2000

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/engineering.yml
@@ -8,6 +8,17 @@
       - id: CMSandbagEmpty50
 
 - type: entity
+  id: RMCCrateSentries
+  parent: RMCCrateConstruction
+  name: sentry crate
+  components:
+  - type: StorageFill
+    contents:
+     - id: RMCSentry
+     - id: RMCSentry
+     - id: RMCSentry
+
+- type: entity
   id: RMCCrateSandbagsConstructionKit
   parent: RMCCrateConstruction
   name: sandbags construction kit

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/restricted_equipment.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/restricted_equipment.yml
@@ -17,3 +17,14 @@
     contents:
     - id: CMArmorB12
     - id: CMArmorHelmetM11
+
+- type: entity
+  id: RMCCrateRestrictedEquipmentGuideKits
+  parent: RMCCrateBase
+  name: guide kits crate (1x medical, 1x engineering, 1x JTAC)
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCKitJTAC
+    - id: RMCKitMedical
+    - id: RMCKitEngineering

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -83,7 +83,7 @@
   - type: XenoHeavy
   - type: XenoAcid
   - type: XenoConstruction
-    buildDelay: 2
+    buildDelay: 0.5
     canBuild:
     - WallXenoResin
     - WallXenoMembrane

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
@@ -58,8 +58,8 @@
   - type: XenoDevour
   - type: XenoHide
   - type: XenoPlasma
-    plasma: 0
-    maxPlasma: 0
+    plasma: 300
+    maxPlasma: 300
     plasmaRegenOnWeeds: 0
   - type: CMArmor
     explosionArmor: 10
@@ -109,8 +109,8 @@
       sprite: _RMC14/Interface/map_blips.rsi
       state: runner
   - type: MovementSpeedModifier
-    baseWalkSpeed: 5.55
-    baseSprintSpeed: 10
+    baseWalkSpeed: 4.44 # just barely slower than a human lol
+    baseSprintSpeed: 8
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.1
   - type: MobCollision
@@ -142,6 +142,7 @@
     - ActionXenoLeap
     - ActionXenoBoneChips
     - ActionXenoZoom
+    - ActionXenoTailSweep
     - ActionXenoDevolve
   - type: XenoBoneChips
   - type: XenoLeap
@@ -149,11 +150,15 @@
     knockdownTime: 2
     leapSound: /Audio/_RMC14/Xeno/alien_pounce.ogg
   - type: MovementSpeedModifier
-    baseWalkSpeed: 5.55
-    baseSprintSpeed: 10
+    baseWalkSpeed: 4.44
+    baseSprintSpeed: 8
   - type: XenoEvolution
     strains:
     - RMCXenoRunnerAcider
+  - type: XenoTailSweep
+    damage:
+      types:
+        Slash: 30
 
 - type: entity
   parent: CMXenoRunnerBase

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/pamphlets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/pamphlets.yml
@@ -23,21 +23,37 @@
 - type: entity
   parent: CMPamphlet
   id: CMPamphletMedical
-  name: medical instructional pamphlet
-  description: A pamphlet used to quickly impart vital knowledge. This one has a medical insignia.
+  name: How To Not Kill Yourself With Injectors
+  description: A pamphlet used to quickly impart vital knowledge. This one is a PSA on properly using injectors, sharing new techniques.
   components:
   - type: Sprite
     state: pamphlet_medical
   - type: SkillPamphlet
     addSkills:
       RMCSkillMedical: 1
+  bypassLimit: true
 
-# gives miniengie skill
+- type: entity
+  parent: CMPamphlet
+  id: CMPamphletMedicalProfessional
+  name: Medical Professional's Handbook
+  description: A pamphlet used to quickly impart vital knowledge. This one is a guide to advanced medical procedures.
+  components:
+  - type: Sprite
+    state: pamphlet_medical
+  - type: SkillPamphlet
+    addSkills:
+      RMCSkillMedical: 1
+    skillCap:
+      RMCSkillMedical: 2
+    bypassLimit: true
+
+# gives engie skill
 - type: entity
   parent: CMPamphlet
   id: CMPamphletEngineer
-  name: engineer instructional pamphlet
-  description: A pamphlet used to quickly impart vital knowledge. This one has an engineering insignia.
+  name: Basic Engineering & Construction; Screwing In A Lightbulb, Idiot's First Barricade
+  description: A pamphlet used to quickly impart vital knowledge. This one instructs you on basic engineering work.
   components:
   - type: Sprite
     state: pamphlet_construction
@@ -45,26 +61,88 @@
     addSkills:
       RMCSkillEngineer: 1
       RMCSkillConstruction: 1
+    bypassLimit: true
+
+- type: entity
+  parent: CMPamphlet
+  id: CMPamphletAdvancedEngineering
+  name: Engineering; Generators, Powernets, Explosives
+  description: A pamphlet used to quickly impart vital knowledge. This one instructs you on engineering work.
+  components:
+  - type: Sprite
+    state: pamphlet_construction
+  - type: SkillPamphlet
+    addSkills:
+      RMCSkillEngineer: 1
+    skillCap:
+      RMCSkillEngineer: 2
+    bypassLimit: true
+
+- type: entity
+  parent: CMPamphlet
+  id: CMPamphletEngineerConstruction
+  name: Construction; Construction Worker's Insights
+  description: A pamphlet used to quickly impart vital knowledge. This one instructs you on engineering work.
+  components:
+  - type: Sprite
+    state: pamphlet_construction
+  - type: SkillPamphlet
+    addSkills:
+      RMCSkillConstruction: 1
+    skillCap:
+      RMCSkillConstruction: 2
+    bypassLimit: true
 
 # gives jtac skill
 - type: entity
   parent: CMPamphlet
   id: CMPamphletJTAC
-  name: JTAC instructional pamphlet
-  description: A pamphlet used to quickly impart vital knowledge. This one has the image of a radio on it.
+  name: JTAC; Baby's First Steps
+  description: A pamphlet used to quickly impart vital knowledge. This one instructs you on doing basic JTAC work.
   components:
   - type: Sprite
     state: pamphlet_jtac
   - type: SkillPamphlet
     addSkills:
       RMCSkillJtac: 1
+    bypassLimit: true
+
+- type: entity
+  parent: CMPamphlet
+  id: CMPamphletJTACTrained
+  name: JTAC; Introduction To Your Sky Buddy
+  description: A pamphlet used to quickly impart vital knowledge. This one instructs you on doing proper JTAC work.
+  components:
+  - type: Sprite
+    state: pamphlet_jtac
+  - type: SkillPamphlet
+    addSkills:
+      RMCSkillJtac: 1
+    skillCap:
+      RMCSkillJtac: 2
+    bypassLimit: true
+
+- type: entity
+  parent: CMPamphlet
+  id: CMPamphletJTACProfessional
+  name: JTAC; Professional's Manual
+  description: A pamphlet used to quickly impart vital knowledge. This one instructs you on tips and tricks that JTAC operators use. You doubt they're that useful.
+  components:
+  - type: Sprite
+    state: pamphlet_jtac
+  - type: SkillPamphlet
+    addSkills:
+      RMCSkillJtac: 1
+    skillCap:
+      RMCSkillJtac: 3
+    bypassLimit: true
 
 # gives spotter skill / bypasses limit
 - type: entity
   parent: CMPamphlet
   id: CMPamphletSpotter
-  name: spotter instructional pamphlet
-  description: A pamphlet used to quickly impart vital knowledge. This one has the image of a pair of binoculars on it.
+  name: Basic Spotting 101
+  description: A pamphlet used to quickly impart vital knowledge. This one instructs you on working as a spotter.
   components:
   - type: Sprite
     state: pamphlet_spotter
@@ -82,16 +160,16 @@
     giveMapBlip:
       sprite: _RMC14/Interface/map_blips.rsi
       state: spotter
-    jobWhitelists:
-    - popup: rmc-pamphlets-rifleman-warning
-      jobProto: CMRifleman
+    # jobWhitelists:
+    # - popup: rmc-pamphlets-rifleman-warning
+    #   jobProto: CMRifleman
 
 # gives powerloader skill / bypasses limit
 - type: entity
   parent: CMPamphlet
   id: CMPamphletPowerloader
-  name: powerloader instructional pamphlet
-  description: A pamphlet used to quickly impart vital knowledge. This one has a powerloader insignia. The title reads 'Moving freight and squishing heads - a practical guide to a Work Loader'.
+  name: Passing Forklift Certification; Professional's Guide
+  description: A pamphlet used to quickly impart vital knowledge. This one has a powerloader insignia. The title reads 'Moving freight and squishing heads - a professional's guide to Work Loader.
   components:
     - type: Sprite
       state: pamphlet_powerloader
@@ -104,8 +182,8 @@
 - type: entity
   parent: CMPamphlet
   id: CMPamphletPolice
-  name: policing instructional pamphlet
-  description: A pamphlet used to quickly impart vital knowledge. This one has the image of a radio on it.
+  name: Policeman's Guide To Beating People Up
+  description: A pamphlet used to quickly impart vital knowledge. This one instructs you on how to operate police gear.
   components:
   - type: Sprite
     state: pamphlet_jtac
@@ -118,8 +196,8 @@
 - type: entity
   parent: CMPamphlet
   id: CMPamphletSurgery
-  name: surgery instructional pamphlet
-  description: A pamphlet used to quickly impart vital knowledge. This one has a medical insignia.
+  name: Cutting A Person Open; Surgeon's Insight
+  description: A pamphlet used to quickly impart vital knowledge. This one instructs you on doing basic surgeries.
   components:
   - type: Sprite
     state: pamphlet_medical
@@ -128,12 +206,25 @@
       RMCSkillSurgery: 1
     bypassLimit: true
 
+- type: entity
+  parent: CMPamphletSurgery
+  id: CMPamphletSurgeryProfessional
+  name: Surgery; Professional Guide
+  description: A pamphlet used to quickly impart vital knowledge. This one instructs you on doing advanced surgeries.
+  components:
+  - type: SkillPamphlet
+    addSkills:
+      RMCSkillSurgery: 1
+    skillCap:
+      RMCSkillSurgery: 2
+    bypassLimit: true
+
 # gives intel skill / bypasses limit
 - type: entity
   parent: CMPamphlet
   id: CMPamphletIntel
-  name: field intelligence instructional pamphlet
-  description: A pamphlet used to quickly impart vital knowledge. This one has an intelligence insignia.
+  name: Collecting Papers; Basic Guide
+  description: A pamphlet used to quickly impart vital knowledge. This one instructs you on how to properly do intelwork.
   components:
   - type: Sprite
     state: pamphlet_reading
@@ -147,8 +238,8 @@
 - type: entity
   parent: CMPamphlet
   id: RMCPamphletLoader
-  name: loader instructional pamphlet
-  description: A pamphlet used to quickly impart vital knowledge. This one has the image of a rocket on it.
+  name: Loading The Boomstick 101
+  description: A pamphlet used to quickly impart vital knowledge. This instructs you on loading a rocket launcher.
   components:
   - type: Sprite
     state: pamphlet_loader
@@ -174,8 +265,8 @@
 - type: entity
   parent: CMPamphlet
   id: RMCPamphletMortarOperator
-  name: mortar operator instructional pamphlet
-  description: A pamphlet used to quickly impart vital knowledge. This one has the image of a mortar on it.
+  name: Groundside Fireworks
+  description: A pamphlet used to quickly impart vital knowledge. This one instructs you on using a mortar. 
   components:
   - type: Sprite
     state: pamphlet_mortar
@@ -196,9 +287,9 @@
       sprite: _RMC14/Interface/map_blips.rsi
       state: mortar
     bypassLimit: true
-    jobWhitelists:
-    - popup: rmc-pamphlets-rifleman-warning
-      jobProto: CMRifleman
+    # jobWhitelists:
+    # - popup: rmc-pamphlets-rifleman-warning
+    #   jobProto: CMRifleman
 
 # LANGUAGE / bypasses limit
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/pamphlets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/pamphlets.yml
@@ -1,0 +1,73 @@
+- type: entity
+  parent: RMCKitBase
+  id: RMCKitMedical
+  name: medical kit
+  description: Contains a synth graft, surgical line, lifesaver bag, and medical guides.
+  components:
+  - type: Item
+    size: Ginormous
+  - type: Storage
+    maxItemSize: Ginormous
+    grid:
+    - 0,0,7,0
+  - type: Sprite
+    sprite: _RMC14/Objects/Storage/procase_mini.rsi
+  - type: Icon
+    sprite: _RMC14/Objects/Storage/procase_mini.rsi
+  - type: StorageFill
+    contents:
+    - id: CMPamphletMedical
+    - id: CMPamphletMedicalProfessional
+    - id: CMSynthGraft
+    - id: CMSurgicalLine
+    - id: CMBeltMedicBag
+
+- type: entity
+  parent: RMCKitBase
+  id: RMCKitEngineeringPamphlets
+  name: engineering kit
+  description: Contains one stack of metal sheets, welding goggles, combat utility belt, and engineering guides.
+  components:
+  - type: Item
+    size: Ginormous
+  - type: Storage
+    maxItemSize: Ginormous
+    grid:
+    - 0,0,9,0
+  - type: Sprite
+    sprite: _RMC14/Objects/Storage/procase_mini.rsi
+  - type: Icon
+    sprite: _RMC14/Objects/Storage/procase_mini.rsi
+  - type: StorageFill
+    contents:
+    - id: CMPamphletEngineer
+    - id: CMPamphletAdvancedEngineering
+    - id: CMPamphletEngineerConstruction
+    - id: CMSheetMetal
+    - id: RMCWeldingGoggles
+    - id: CMBeltUtilityCombat
+
+- type: entity
+  parent: RMCKitBase
+  id: RMCKitJTAC
+  name: JTAC kit
+  description: Contains a laser designator, CAS flares, and JTAC guides.
+  components:
+  - type: Item
+    size: Ginormous
+  - type: Storage
+    maxItemSize: Ginormous
+    grid:
+    - 0,0,9,0
+  - type: Sprite
+    sprite: _RMC14/Objects/Storage/procase_mini.rsi
+  - type: Icon
+    sprite: _RMC14/Objects/Storage/procase_mini.rsi
+  - type: StorageFill
+    contents:
+    - id: CMPamphletJTAC
+    - id: CMPamphletJTACTrained
+    - id: CMPamphletJTACProfessional
+    - id: RMCLaserDesignator
+    - id: RMCPackFlareCAS
+    - id: RMCPackFlareCAS

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/shotgun_pellets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Shotguns/shotgun_pellets.yml
@@ -43,6 +43,10 @@
     - range: 4
       falloff: 10
   - type: RMCStunOnHit
+    stunTime: 0.3
+    maxRange: 3
+    superSlowTime: 0.5
+    slowTime: 1.5
 
 - type: entity
   parent: CMPelletShotgunBase
@@ -69,9 +73,9 @@
     amount: 20
   - type: RMCStunOnHit
     maxRange: 6.5
-    stunTime: 1
-    superSlowTime: 2
-    slowTime: 6
+    stunTime: 0.6
+    superSlowTime: 1
+    slowTime: 3
   - type: RMCProjectileAccuracy
     accuracy: 100
     thresholds:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/engineer.yml
@@ -43,11 +43,11 @@
         points: 3
       - id: CMSheetMetal10
         name: metal x10
-        points: 5
+        points: 3
         recommended: true
       - id: CMSheetPlasteel10
         name: plasteel x10
-        points: 7
+        points: 5
         recommended: true
       - id: RMCExplosivePlastic
         points: 3
@@ -180,10 +180,14 @@
         points: 12
       - id: RMCVisorWelding
         points: 5
-    - name: Pamphlets
+      - id: RMCVisorNightVision
+        points: 35
+    - name: Skills
       entries:
-      - id: CMPamphletJTAC
+      - id: RMCKitJTAC
         points: 15
+      - id: RMCKitMedical
+        points: 30
     - name: Radio Keys
       entries:
       - id: CMEncryptionKeyIntel

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/leader.yml
@@ -30,7 +30,9 @@
       - id: RMCM79Case
       - id: RMCMOU53Case
       - id: RMCCaseXM88
-      - id: RMCKitEngineering
+      - id: RMCKitEngineeringPamphlets
+      - id: RMCKitMedical
+      - id: RMCKitJTAC
     - name: Armors
       entries:
       - id: RMCArmorM4Zipties

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
@@ -184,10 +184,13 @@
       entries:
       - id: RMCVisorWelding
         points: 5
-    - name: Pamphlets
+      - id: RMCVisorNightVision
+        points: 35
+    - name: Skills
       entries:
-      - id: CMPamphletEngineer
+      - id: RMCKitJTAC
         points: 15
+      - id: RMCKitEngineeringPamphlets
     - name: Radio Keys
       entries:
       - id: CMEncryptionKeyEngineer

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/medic.yml
@@ -31,7 +31,6 @@
 #        recommended: true
       - id: CMBloodPackFull # TODO RMC14 O-
         name: blood bag (O-)
-        points: 4
     - name: Firstaid Kits
       entries:
       - id: CMAdvFirstAidKitFilled
@@ -50,16 +49,11 @@
     - name: Pill Bottles
       entries:
       - id: CMPillCanisterBicaridine
-        points: 5
         recommended: true
       - id: CMPillCanisterDexalin
-        points: 5
       - id: CMPillCanisterDylovene
-        points: 5
       - id: CMPillCanisterInaprovaline
-        points: 5
       - id: CMPillCanisterKelotane
-        points: 5
         recommended: true
 #      - id: CMPillCanisterPeridaxon
 #        points: 5
@@ -69,21 +63,15 @@
     - name: Autoinjectors
       entries:
       - id: CMBicaridineAutoInjector
-        points: 1
       - id: CMDexalinPlusAutoInjector
-        points: 1
       - id: CMEpinephrineAutoInjector
-        points: 2
       - id: CMInaprovalineAutoInjector
-        points: 1
       - id: CMKelotaneAutoInjector
-        points: 1
 #      - id: CMAutoinjectorOxycodone
 #        points: 2
 #      - id: CMAutoinjectorTramadol
 #        points: 1
       - id: CMTricordrazineAutoInjector
-        points: 1
     - name: Medical Utilities
       entries:
      #    CMMS11SmartRefillTank: 6P
@@ -93,7 +81,6 @@
       - id: CMHealthAnalyzer
         points: 4
       - id: CMStasisBagFolded
-        points: 6
     - name: Explosives
       entries:
       - id: CMPacketGrenadeHighExplosiveFilled

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/prep.yml
@@ -18,70 +18,44 @@
     - name: Primary firearms
       entries:
       - id: WeaponRifleM4SPR
-        amount: 10
       - id: WeaponShotgunM42A2
-        amount: 15
       - id: WeaponSMGM63
-        amount: 30
       - id: WeaponRifleM54C
-        amount: 30
         recommended: true
     - name: Primary ammunition
       entries:
       - id: RMCBoxShotgunFlechette
-        amount: 4
       - id: RMCBoxShotgunBuckshot
-        amount: 10
       - id: RMCBoxShotgunSlugs
-        amount: 10
       - id: CMMagazineRifleM4SPR
-        amount: 15
       - id: CMMagazineSMGM63
-        amount: 25
       - id: CMMagazineRifleM54C
-        amount: 25
     - name: Sidearms
       entries:
       - id: RMCWeaponPistolM77Empty
-        amount: 25
       - id: RMCWeaponRevolverM44Empty
-        amount: 25
       - id: CMWeaponPistolM1984Empty
-        amount: 25
       - id: RMCWeaponPistolM13Empty
-        amount: 25
       - id: RMCWeaponPistolM82F
-        amount: 10
     - name: Sidearm ammunition
       entries:
       - id: CMMagazinePistolM77AP
-        amount: 25
       - id: RMCSpeedLoaderM44
-        amount: 20
       - id: CMMagazinePistolM1984
-        amount: 25
       - id: RMCMagazinePistolM13
-        amount: 25
     - name: Attachments
       entries:
       - id: RMCAttachmentM63StockCollapsible
-        amount: 10
       - id: RMCAttachmentM54CStockCollapsible
-        amount: 10
       - id: RMCAttachmentRailFlashlight
-        amount: 25
         recommended: true
       - id: RMCAttachmentFlashlightGrip
-        amount: 10
         recommended: true
       - id: RMCAttachmentU1GrenadeLauncher
-        amount: 25
     - name: Utilities
       entries:
       - id: RMCM5Bayonet
-        amount: 25
       - id: CMPackFlare
-        amount: 10
         recommended: true
 
 - type: entity
@@ -103,69 +77,41 @@
     - name: Standard Equipment
       entries:
       - id: CMBootsBlack
-        amount: 15
       - id: CMBootsBrown
-        amount: 15
       - id: JumpsuitMarine
-        amount: 15
       - id: CMHandsBrown
-        amount: 15
       - id: CMHandsBlackMarine
-        amount: 15
       - id: CMHeadset
-        amount: 15
       - id: ArmorHelmetM10
-        amount: 15
     - name: Webbings
       entries:
       - id: CMWebbingBrown
-        amount: 1
       - id: CMWebbingBlack
-        amount: 1
       - id: CMWebbing
-        amount: 2
       - id: RMCWebbingDropPouch
-        amount: 1
       - id: CMWebbingHolster
-        amount: 1
     - name: Armor
       entries:
       - id: RMCArmorM3MediumCarrier
-        amount: 15
       - id: RMCArmorM3MediumPadded
-        amount: 15
       - id: RMCArmorM3MediumPadless
-        amount: 15
       - id: RMCArmorM3MediumRidged
-        amount: 15
       - id: RMCArmorM3MediumSkull
-        amount: 15
       - id: RMCArmorM3MediumSmooth
-        amount: 15
       - id: RMCArmorM3HeavyPadded
-        amount: 10
       - id: RMCArmorM3LightPadded
-        amount: 10
     - name: Backpack
       entries:
       - id: CMBackpackMarine
-        amount: 15
       - id: CMBackpackMarineTech
-        amount: 15
       - id: CMBackpackMedical
-        amount: 15
       - id: CMSatchelMarine
-        amount: 15
 #      - id: Marine Chestrig
 #        amount: 15
       - id: CMSatchelMarineTech
-        amount: 15
       - id: RMCSatchelWelderChestrig
-        amount: 15
       - id: CMSatchelMedical
-        amount: 15
       - id: RMCScabbardShotgun
-        amount: 5
     - name: Restricted Backpacks
       entries:
       - id: CMBackpackWelder
@@ -177,133 +123,88 @@
     - name: Belts
       entries:
       - id: CMBeltMarine
-        amount: 15
       - id: RMCBeltGrenade
-        amount: 10
       - id: RMCM276ShotgunShellLoadingRig
-        amount: 15
       - id: RMCBeltHolsterPistol
-        amount: 15
       - id: RMCBeltHolsterM13
-        amount: 15
       - id: RMCBeltHolsterRevolver
-        amount: 15
       - id: RMCBeltHolsterSMG
-        amount: 15
       - id: RMCBeltHolsterSMGPouch
-        amount: 10
       - id: RMCM82FHolster
-        amount: 5
       - id: CMBeltKnifeFilled
         name: M276 Knife Rig (Full)
-        amount: 15
       - id: RMCBeltUtilityGeneral
-        amount: 15
     - name: Pouches
       entries:
       - id: RMCPouchBayonetFill
         name: Bayonet Sheath (Full)
-        amount: 15
       - id: RMCPouchFirstAidSplintsGauzeOintment
         name: First-Aid Pouch (Splints, Gauze, Ointment)
-        amount: 15
       - id: RMCPouchFirstAidPills
         name: First-Aid Pouch (Pill Packets)
-        amount: 15
       - id: RMCPouchFlareFilled
         name: Flare Pouch (Full)
-        amount: 15
       - id: RMCPouchDocumentSmall
-        amount: 15
       - id: RMCPouchMagazine
-        amount: 15
       - id: RMCPouchShotgun
-        amount: 15
       - id: RMCPouchGeneralMedium
-        amount: 15
       - id: RMCPouchMagazinePistol
-        amount: 15
       - id: RMCPouchPistol
-        amount: 15
     - name: Restricted Pouches
       entries:
       - id: RMCPouchConstruction
-        amount: 1
       - id: RMCPouchExplosive
-        amount: 1
       - id: RMCPouchFirstResponder
         name: First Responder Pouch (Empty)
-        amount: 2
       - id: RMCPouchMagazinePistolLarge
         amount: 2
-      - id: RMCPouchTools
+      - id: RMCPouchMagazineLarge
         amount: 1
+      - id: RMCPouchTools
 #      - id: Sling Pouch
 #        amount: 1
     - name: Mask
       entries:
       - id: CMMaskGas
-        amount: 15
       - id: CMMaskCoif
-        amount: 10
       - id: RMCMaskRebreather
-        amount: 10
     - name: Miscellaneous
       entries:
       - id: RMCGogglesBallistic
-        amount: 10
       - id: RMCGogglesBallisticSquad
-        amount: 10
       - id: RMCGogglesM1A1Ballistic
-        amount: 10
       - id: RMCGogglesPrescriptionBallistic
-        amount: 10
       - id: RMCGlassesMarineRpg
-        amount: 10
       - id: RMCGlassesMarineRpgOld
-        amount: 10
       - id: RMCHelmetGarbGasmask
         name: M5 integrated gas mask
-        amount: 10
       - id: RMCHelmetGarbNetting
         name: M10 helmet netting
-        amount: 10
       - id: RMCHelmetGarbRainCover
         name: M10 helmet rain cover
-        amount: 10
       - id: RMCHelmetGarbGunOil
         name: firearm lubricant
-        amount: 15
 #      - id: TODO UNMC Flair
 #        amount: 15
       - id: RMCPatchFallingFalcons
-        amount: 15
       - id: RMCPatchFallingFalconsAlt
         name: Falling Falcons UN shoulder patch
-        amount: 15
       - id: RMCPatchFallingFalconsLarge
         name: Falling Falcons large chest patch
-        amount: 15
       - id: RMCPatchUNMC
         name: UNMC shoulder patch
-        amount: 15
       - id: RMCPatchUnitedNations
         name: United Nations shoulder patch
-        amount: 15
       - id: RMCPatchUnitedNationsSquare
         name: United Nations flag shoulder patch
-        amount: 15
       - id: BedrollFolded
-        amount: 20
       - id: RMCM5CameraGear
-        amount: 10
     - name: Optics
       entries:
       - id: RMCVisorMedicalAdvanced
         name: advanced medical optic (CORPSMAN ONLY)
         amount: 4
       - id: RMCVisorSquad
-        amount: 15
 
 - type: entity
   parent: ColMarTechSurplus
@@ -374,7 +275,6 @@
       #- id: CMMagazineBoxM2C
       #  amount: 2
       - id: RMCBoxShotgunBreaching
-        amount: 2
       - id: RMCBatonSlugHIRR
         amount: 6
       - id: RMCStarShellM74AGMS
@@ -403,37 +303,24 @@
     - name: Food
       entries:
       - id: CMMRE
-        amount: 5
       - id: RMCBoxMRE
-        amount: 1
     - name: Tools
       entries:
       - id: CMEntrenchingTool
-        amount: 2
       - id: CMScrewdriver
-        amount: 5
       - id: CMWirecutter
-        amount: 5
       - id: CMCrowbar
-        amount: 5
       - id: CMWrench
-        amount: 5
       - id: CMMultitool
-        amount: 1
-      - id: CMWelderSmall
-        amount: 1
+      - id: CMWelder
     - name: Flare and light
       entries:
       - id: RMCFlashlight # Combat Flashlight
-        amount: 5
       - id: RMCBoxFlashlights
-        amount: 1
       - id: RMCBoxPackFlare
-        amount: 1
       - id: CMPackFlare
-        amount: 10
       - id: RMCPackFlareCAS
-        amount: 1
+        amount: 2
     - name: Miscellaneous
       entries:
       - id: RMCEngineerKit
@@ -441,24 +328,18 @@
       #- id: CMMap
       #  amount: 5
       - id: CMFireExtinguisher
-        amount: 5
       - id: CMFireExtinguisherPortable
-        amount: 1
       - id: CMRollerBedSpawnFolded
-        amount: 1
       - id: RMCScabbardMacheteFilled
         name: machete scabbard (Full)
         amount: 5
       - id: RMCBinoculars
-        amount: 1
       #- id: CMFoldingBarricadesMB6x3
       #  amount: 2
       #- id: CMSparePDTLBattleBuddyKit
       #  amount: 3
       - id: RMCPowerCellCrap
-        amount: 2
       - id: RMCMagazineSMGNailgun
-        amount: 2
 
 - type: entity
   parent: ColMarTechUtilities
@@ -489,58 +370,35 @@
     - name: Barrel
       entries:
       - id: RMCAttachmentExtendedBarrel
-        amount: 3
       - id: RMCAttachmentRecoilCompensator
-        amount: 3
       - id: RMCAttachmentSuppressor
-        amount: 3
       # - id: RMCAttachmentShotgunChoke
       #   amount: 2
     - name: Rail
       entries:
       - id: RMCAttachmentB8SmartScope
-        amount: 2
       - id: RMCAttachmentMagneticHarness
-        amount: 4
       - id: RMCAttachmentS42xTelescopicMiniscope
-        amount: 2
       - id: RMCAttachmentS5RedDotSight
-        amount: 3
       - id: RMCAttachmentS6ReflexSight
-        amount: 3
       - id: RMCAttachmentS84xTelescopicScope
-        amount: 2
     - name: Underbarrel
       entries:
       - id: RMCAttachmentAngledGrip
-        amount: 3
       - id: RMCAttachmentBipod
-        amount: 3
       - id: RMCAttachmentBurstFireAssembly
-        amount: 2
       - id: RMCAttachmentGyroscopicStabilizer
-        amount: 2
       - id: RMCAttachmentLaserSight
-        amount: 3
       - id: RMCAttachmentMiniFlamethrower
-        amount: 2
 #      - id: CMAttachmentXMVESG1FlamerNozzle
 #        amount: 2
       - id: RMCAttachmentU7UnderbarrelShotgun
-        amount: 2
       - id: RMCAttachmentUnderbarrelExtinguisher
-        amount: 2
       - id: RMCAttachmentVerticalGrip
-        amount: 3
     - name: Stock
       entries:
       - id: RMCAttachmentM42A2WoodenStock
-        amount: 2
       - id: RMCAttachmentM63ArmBrace
-        amount: 2
       - id: RMCAttachmentM63Stock
-        amount: 2
       - id: RMCAttachmentM54CStockSolid
-        amount: 2
       - id: RMCAttachmentM44MagnumSharpshooterStock
-        amount: 2

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/rifleman.yml
@@ -217,11 +217,15 @@
         points: 15
       - id: RMCVisorWelding
         points: 5
-    - name: Pamphlets
+      - id: RMCVisorNightVision
+        points: 45
+    - name: Skills
       entries:
-      - id: CMPamphletJTAC
-        points: 15
-      - id: CMPamphletEngineer
+      - id: RMCKitMedical
+        points: 30
+      - id: RMCKitEngineeringPamphlets
+        points: 30
+      - id: RMCKitJTAC
         points: 15
     - name: Radio Keys
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/smart_gun_operator.yml
@@ -103,12 +103,14 @@
         points: 15
       - id: RMCVisorWelding
         points: 5
-    - name: Pamphlets
+    - name: Skills
       entries:
-      - id: CMPamphletJTAC
+      - id: RMCKitJTAC
         points: 15
-      - id: CMPamphletEngineer
-        points: 15
+      - id: RMCKitEngineering
+        points: 30
+      - id: RMCKitMedical
+        points: 30
     - name: Radio Keys
       entries:
       - id: CMEncryptionKeyEngineer

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
@@ -319,10 +319,12 @@
         points: 5
     - name: Pamphlets
       entries:
-      - id: CMPamphletJTAC
+      - id: RMCKitJTAC
         points: 15
-      - id: CMPamphletEngineer
-        points: 15
+      - id: RMCKitEngineering
+        points: 30
+      - id: RMCKitMedical
+        points: 30
     - name: Radio Keys
       entries:
       - id: CMEncryptionKeyEngineer

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/team_leader.yml
@@ -141,6 +141,10 @@
         points: 15
       - id: RMCVisorWelding
         points: 5
+    - name: Skills
+      entries:
+      - id: RMCKitMedical
+        points: 30
     - name: Radio Keys
       entries:
       - id: CMEncryptionKeyEngineer

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/medical.yml
@@ -64,41 +64,28 @@
       - id: CMTraumaKit10
         amount: 6
       - id: CMOintment10
-        amount: 6
       - id: CMGauze10
-        amount: 6
 #      - id: CMSplints10 # TODO RMC14
 #        amount: 6
     - name: Autoinjectors
       entries:
       - id: CMBicaridineAutoInjector
-        amount: 3
       - id: CMDexalinPlusAutoInjector
-        amount: 3
       - id: CMEpinephrineAutoInjector
-        amount: 3
       - id: CMInaprovalineAutoInjector
-        amount: 3
       - id: CMKelotaneAutoInjector
-        amount: 3
 #      - id: CMOxycodoneAutoinjector # TODO RMC14
 #        amount: 3
 #      - id: CMTramadolAutoinjector # TODO RMC14
 #        amount: 3
       - id: CMTricordrazineAutoInjector
-        amount: 3
     - name: Liquid bottles
       entries:
       - id: CMBottleBicaridine
-        amount: 3
       - id: CMBottleDylovene
-        amount: 3
       - id: CMBottleDexalin
-        amount: 3
       - id: CMBottleInaprovaline
-        amount: 3
       - id: CMBottleKelotane
-        amount: 3
 #      - id: CMBottleOxycodone # TODO RMC14
 #        amount: 3
 #      - id: CMBottlePeridaxon # TODO RMC14
@@ -108,15 +95,10 @@
     - name: Pill bottles
       entries:
       - id: CMPillCanisterBicaridine
-        amount: 2
       - id: CMPillCanisterDexalin
-        amount: 2
       - id: CMPillCanisterDylovene
-        amount: 2
       - id: CMPillCanisterInaprovaline
-        amount: 2
       - id: CMPillCanisterKelotane
-        amount: 2
 #      - id: CMPillCanisterPeridaxon # TODO RMC14
 #        amount: 2
 #      - id: CMPillCanisterTramadol # TODO RMC14
@@ -124,23 +106,14 @@
     - name: Medical utilities
       entries:
       - id: CMDefibrillator
-        amount: 3
       - id: CMSurgicalLine
-        amount: 2
       - id: CMSynthGraft
-        amount: 2
       - id: CMHyposprayFilledTricord
-        amount: 2
       - id: CMHealthAnalyzer
-        amount: 5
       - id: CMBeltMedical
-        amount: 2
       - id: RMCGlassesMedicalHUDGlasses
-        amount: 3
       - id: CMStasisBagFolded
-        amount: 2
       - id: CMSyringe
-        amount: 7
 
 - type: entity
   parent: CMVendorMedicalAllAccess
@@ -174,15 +147,10 @@
     - name: Liquid bottles
       entries:
       - id: CMBottleBicaridine
-        amount: 6
       - id: CMBottleDylovene
-        amount: 6
       - id: CMBottleDexalin
-        amount: 6
       - id: CMBottleInaprovaline
-        amount: 6
       - id: CMBottleKelotane
-        amount: 6
     #      - id: CMBottleOxycodone # TODO RMC14
     #        amount: 6
     #      - id: CMBottlePeridaxon # TODO RMC14
@@ -193,16 +161,11 @@
       entries:
       - id: CMBeaker
         name: Beaker (60 units)
-        amount: 3
       - id: CMBeakerLarge
         name: Beaker, Large (120 units)
-        amount: 3
       - id: RMCBoxPillCanister
-        amount: 2
       - id: RMCDropper
-        amount: 3
       - id: CMSyringe
-        amount: 7
 
 
 - type: entity
@@ -245,20 +208,15 @@
     - name: Autoinjectors
       entries:
       - id: CMTricordrazineAutoInjectorNoSkill
-        amount: 5
     #- id: CMPainStopAutoinjector
     - name: Devices
       entries:
       - id: CMHealthAnalyzer
-        amount: 3
     - name: Field Supplies
       entries:
       - id: CMFireExtinguisherPortable
-        amount: 5
       - id: CMOintment10
-        amount: 7
       - id: CMGauze10
-        amount: 7
 #      - id: CMMedicalSplints5
 #        amount: 7
 
@@ -305,17 +263,13 @@
       # - id: CMPainStopAutoinjector
       #   amount: 2
       - id: CMTricordrazineAutoInjectorNoSkill
-        amount: 2
       - id: CMGauze10
-        amount: 4
       - id: CMOintment10
-        amount: 4
       # - id: CMMedicalSplints5
       #   amount: 4
     - name: Utility
       entries:
       - id: CMHealthAnalyzer
-        amount: 3
 
 - type: entity
   parent: ColMarTechBaseAnchorable
@@ -347,9 +301,7 @@
     - name: Blood Packs
       entries:
       - id: CMBloodPackFull
-        amount: 30
     - name: Miscellaneous
       entries:
       - id: CMBloodPack
-        amount: 5
         name: empty blood pack

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/hospital_corpsman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/hospital_corpsman.yml
@@ -38,9 +38,10 @@
       skills:
         RMCSkillFirearms: 1
         RMCSkillFireman: 1
+        RMCSkillConstruction: 1
         RMCSkillJtac: 1
         RMCSkillMedical: 2
-        RMCSkillSurgery: 1
+        RMCSkillSurgery: 2 # fuck you larvas
     - type: CMVendorUser
       points: 45
     - type: SquadArmorWearer

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/rifleman.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/rifleman.yml
@@ -30,6 +30,8 @@
       skills:
         RMCSkillEndurance: 1
         RMCSkillFirearms: 1
+        RMCSkillConstruction: 1
+        RMCSkillFireman: 1
     - type: CMVendorUser
       points: 45
     - type: SquadArmorWearer

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/smart_gun_operator.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/smart_gun_operator.yml
@@ -36,6 +36,7 @@
       skills:
         RMCSkillFirearms: 1
         RMCSkillFireman: 1
+        RMCSkillConstruction: 1
         RMCSkillJtac: 1
         RMCSkillSmartGun: 1
     - type: CMVendorUser

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/squad_leader.yml
@@ -51,8 +51,8 @@
         RMCSkillFireman: 1
         RMCSkillIntel: 1
         RMCSkillJtac: 2
-        RMCSkillLeadership: 1
-        RMCSkillMedical: 1
+        RMCSkillLeadership: 2
+        RMCSkillMedical: 2
         RMCSkillVehicles: 1
         RMCSkillPolice: 1
     - type: CMVendorUser


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
marines now get infinite ammo, attachments and flares. also med gets inf of that shit.
special mags arent included, aka AP M63 or extended M4SPR.
adds pamphlets for engineering, medical and jtac skills. they can give you full knowledge of said skills.
i also added sentries to cargo orders.

## Why / Balance
coolerio. also curbs the shotgun+m63 meta.
to counter the lack of stun meta, rouny has been slowed down by 2. 2 of something. idfk. it now moves at 8 speed.
to counter the slowness of the rouny, i gave him tail sweep.
queen also builds 4 times faster now to help with hive building.

## Technical details
nun
## Media


https://github.com/user-attachments/assets/cb9fc5ca-c42d-45b6-8e7a-c6baae5f7fcc


## Requirements
nun
**Changelog**
- tweak: Common marine and medical equipment is now infinite. Check your local vendors.
- tweak: Rouny now runs slower, however has tail sweep.
- tweak: Queen now builds faster.
